### PR TITLE
fix: replacing NewM2MRestClient() with NewMaasRestClient()

### DIFF
--- a/client.go
+++ b/client.go
@@ -134,7 +134,7 @@ func (m *m2mRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func getHttpClient() *resty.Client {
-	return resty.New().SetTransport(&m2mRoundTripper{rest.NewM2MRestClient()}).SetRetryCount(10)
+	return resty.New().SetTransport(&m2mRoundTripper{rest.NewMaasRestClient()}).SetRetryCount(10)
 }
 
 func getStompDialer() *websocket.Dialer {


### PR DESCRIPTION
 Problem: NewM2MRestClient does not have fallback logic https://github.com/Netcracker/qubership-core-lib-go/blob/main/security/rest/client.go#L36

When Kubernetes M2M is disabled on the MaaS service, in this case our client should use fallback approach which is part of NewMaasRestClient
https://github.com/Netcracker/qubership-core-lib-go/blob/main/security/rest/client.go#L51

So Replacing NewM2MRestClient() with NewMaasRestClient() to  enable proper fallback to maas-agent when Kubernetes M2M is disabled on the MaaS service.